### PR TITLE
dev-qt/qtwebengine: fix dependencies

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.9.4.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.4.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	media-libs/libpng:0=
 	>=media-libs/libvpx-1.5:=[svc]
 	media-libs/libwebp:=
-	media-libs/mesa
+	media-libs/mesa[egl]
 	media-libs/opus
 	net-libs/libsrtp:0=
 	sys-apps/dbus


### PR DESCRIPTION
skip build if mesa without egl with message:
"khronos development headers appear to be missing(mesa/libegl1-mesa-dev)"

Package-Manager: Portage-2.3.24, Repoman-2.3.6